### PR TITLE
Feature/workout history functionality

### DIFF
--- a/controllers/homeRoutes.js
+++ b/controllers/homeRoutes.js
@@ -69,14 +69,35 @@ router.get("/userlist", async (req, res)=>{
 });
 
 router.get("/history", async (req, res)=>{
-    const workoutData = await Workout.findAll().catch((err) =>  {
-        res.json(err);
+try {
+    const userId = req.session.user_id;
+    const workoutData = await Workout.findAll({
+        where: { user_id: userId }
     });
     const workouts = workoutData.map((workout) => workout.get({ plain: true }));
     res.render("History", {
         workouts,
         logged_in: req.session.logged_in
-    })
+    });
+} catch (err) {
+    res.json(err);
+}
+});
+
+router.get("/history/:id", async (req, res) => {
+    try {
+        const userId = req.params.id;
+        const workoutData = await Workout.findAll({
+            where: { user_id: userId }
+        });
+        const workouts = workoutData.map((workout) => workout.get({ plain: true }));
+        res.render("History", {
+            workouts,
+            logged_in: req.session.logged_in
+        });
+    } catch (err) {
+        res.json(err);
+    }
 });
 
 router.get("/premadeworkouts", (req, res)=>{

--- a/controllers/homeRoutes.js
+++ b/controllers/homeRoutes.js
@@ -7,10 +7,26 @@ router.get('/', (req, res) => {
     })
 });
 
-router.get('/profile', (req, res) => {
-    res.render('Profile', {
+router.get("/profile", async (req, res) => {
+    // this line grabs the user ID from the session info that we save when we login
+    const userId = req.session.user_id;
+
+    // this retrieves the data about the logged in user
+    const userData = await User.findByPk(userId).catch((err) => {
+        res.json(err);
+    });
+
+    if (!userData) {
+        return res.status(404).send("User not found");
+    }
+
+    const user = userData.get({ plain: true });
+
+    // Render the profile page with only the data of the logged in user
+    res.render("Profile", {
+        user,
         logged_in: req.session.logged_in
-    })
+    });
 });
 
 router.get("/profile/:id", async (req, res)=>{
@@ -18,7 +34,7 @@ router.get("/profile/:id", async (req, res)=>{
         res.json(err);
     });
     const user = userData.get({ plain: true })
-    res.render("profile/1", {
+    res.render("Profile", {
         user,
         logged_in: req.session.logged_in
     })

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -21,7 +21,7 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
       <div class="navbar-nav">
-        <a class="nav-link" href="/profile/1">Profile</a>  
+        <a class="nav-link" href="/profile">Profile</a>  
         <a class="nav-link" href="/timeline">Timeline</a> 
         <a class="nav-link" href="/userlist">Users</a> 
         <a class="nav-link" href="premadeworkouts">Premade Workouts</a> 

--- a/views/partials/profile-details.handlebars
+++ b/views/partials/profile-details.handlebars
@@ -1,6 +1,6 @@
 <div class="bg-light">
 <p>Username: {{user.username}} </p>
 <p>Email: {{user.email}} </p>
-<p>Date Joined: {{formatDate.user.date_joined}}</p>
+<p>Date Joined: {{formatDate user.date_joined}}</p>
 <p>Number of Workouts Logged:</p>
 </div>


### PR DESCRIPTION
this does the same thing as the previous push does for the profile page vs. user list, but now i did it for the workout history  too.  essentially it differentiates between the workout history of the logged in user (which you can get to by clicking "workout history" in the nav  bar) from the workout history of other users (which you can get to by going to  the address "/history/:id").  I'm now going to work on making it so that clicking on a "workout history" button on another user's profile page will take you to their workout history